### PR TITLE
Add a few default values to the top-level .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+node_modules
+
+# Ignore configuration and automatically generated cruft
+dbconfig.php
+sitemap.xml
+*.log
+.sass-cache
+
+# Operating system files
+.Spotlight-V100
+.Trashes
+.DS_Store
+.DS_Store?
+ehthumbs.db
+Thumbs.db


### PR DESCRIPTION
Mostly to make sure node_modules isn't accidentally committed.