### PR TITLE
Minor sails unit test changes. Added barrels.

### DIFF
--- a/server/config/connections.js
+++ b/server/config/connections.js
@@ -32,6 +32,10 @@ module.exports.connections = {
     adapter: 'sails-disk'
   },
 
+  test: {
+    adapter: 'sails-disk'
+  },
+
   /***************************************************************************
   *                                                                          *
   * MySQL is the world's most popular relational database.                   *

--- a/server/package.json
+++ b/server/package.json
@@ -30,8 +30,8 @@
     "sails": "^0.11.0",
     "sails-disk": "~0.10.0",
     "sails-generate-ember-blueprints": "0.0.2",
-    "sails-hook-eslint": "^1.0.1",
     "sails-hook-dev": "git://github.com/balderdashy/sails-hook-dev",
+    "sails-hook-eslint": "^1.0.1",
     "sails-mongo": "^0.10.6"
   },
   "scripts": {
@@ -49,6 +49,7 @@
   "license": "",
   "devDependencies": {
     "babel-eslint": "^2.0.2",
+    "barrels": "^1.4.1",
     "chai": "^2.1.0",
     "glob": "^4.4.1",
     "mocha": "^2.1.0",

--- a/server/tests/fixtures/user.json
+++ b/server/tests/fixtures/user.json
@@ -1,17 +1,19 @@
 [
   {
+    "id": 1,
     "firstName": "Peter",
     "lastName": "Test",
     "email": "peter@test.com",
     "password": "super-secure"
   },
   {
+    "id": 2,
     "firstName": "First",
     "lastName": "Last",
     "email": "first@last.at",
     "password": "my-birthdate"
   },
-  {
+  { "id": 3,
     "firstName": "John",
     "lastName": "Original",
     "email": "john.original@email.com",

--- a/server/tests/fixtures/user.json
+++ b/server/tests/fixtures/user.json
@@ -1,0 +1,20 @@
+[
+  {
+    "firstName": "Peter",
+    "lastName": "Test",
+    "email": "peter@test.com",
+    "password": "super-secure"
+  },
+  {
+    "firstName": "First",
+    "lastName": "Last",
+    "email": "first@last.at",
+    "password": "my-birthdate"
+  },
+  {
+    "firstName": "John",
+    "lastName": "Original",
+    "email": "john.original@email.com",
+    "password": "my-birthdate"
+  }
+]

--- a/server/tests/helpers/jwt.js
+++ b/server/tests/helpers/jwt.js
@@ -1,0 +1,15 @@
+var jwt = require('jsonwebtoken');
+var _ = require('lodash');
+var secret = 'RS#$09qu43f09qfj94qf*&H#(R';
+var refreshSecret = 'rw5&&$$2224124f*&H#(R';
+var bcrypt = require('bcrypt');
+
+module.exports = function (user) {
+    var expirationTimeInMinutes = 60 * 2;
+
+    var token = jwt.sign(user, secret, {
+        expiresInMinutes: expirationTimeInMinutes
+    });
+
+    return token;
+};

--- a/server/tests/unit/user-test.js
+++ b/server/tests/unit/user-test.js
@@ -3,7 +3,9 @@ var Sails = require('sails').Sails;
 var sinon = require('sinon');
 var expect = require('chai').expect;
 var path = require('path');
-
+var user = require('../fixtures/user')[0];
+var token = require('../helpers/jwt');
+var _ = require('lodash');
 
 describe('Users', function() {
 
@@ -125,11 +127,10 @@ describe('Users', function() {
         url: '/api/v1/users',
         method: 'GET',
         params: {},
-        headers: {}
+        headers: {'Authorization' : 'Bearer ' + token(user)}
       }, function(err, clientRes, body) {
         expect(err).not.to.exist;
         expect(clientRes.statusCode).to.equal(200);
-        console.log(body);
         expect(body).to.include.keys('posts', 'vendors', 'photos', 'albums', 'statuses', 'events');
         done();
       });
@@ -139,18 +140,19 @@ describe('Users', function() {
       sails.request({
         url: '/api/v1/users',
         method: 'GET',
-        params: {},
-        headers: {}
+        params: {'sort': 'id asc'},
+        headers: {'Authorization' : 'Bearer ' + token(user)}
       }, function(err, clientRes, body) {
-        expect(body).to.have.deep.property('people[0].id');
-        expect(body).to.have.deep.property('people[0].createdAt');
-        console.log(body)
-        expect(body.people[0].firstName).to.equal('Peter');
-        expect(body.people[0].lastName).to.equal('Test');
-        expect(body.people[0].email).to.equal('peter@test.com');
-        expect(body.people[0].password).to.not.equal('super-secure');
-        expect(body.people[1].firstName).to.equal('First');
-        expect(body.people[2].email).to.equal('john.original@email.com');
+
+        console.log('users: ', body.users);
+        expect(body).to.have.deep.property('users[0].id');
+        expect(body).to.have.deep.property('users[0].createdAt');
+        expect(body.users[0].firstName).to.equal('Peter');
+        expect(body.users[0].lastName).to.equal('Test');
+        expect(body.users[0].email).to.equal('peter@test.com');
+        expect(body.users[0].password).to.not.equal('super-secure');
+        expect(body.users[1].firstName).to.equal('First');
+        expect(body.users[2].email).to.equal('john.original@email.com');
         done();
       });
     });
@@ -159,11 +161,11 @@ describe('Users', function() {
 
   describe('after a user is created', function() {
     it('should log the user in');
-  })
+  });
 
   describe('when a user password is changed', function() {
     it('should hash the password');
     it('should keep the user logged in');
-  })
+  });
 
 });

--- a/server/tests/unit/user-test.js
+++ b/server/tests/unit/user-test.js
@@ -144,7 +144,6 @@ describe('Users', function() {
         headers: {'Authorization' : 'Bearer ' + token(user)}
       }, function(err, clientRes, body) {
 
-        console.log('users: ', body.users);
         expect(body).to.have.deep.property('users[0].id');
         expect(body).to.have.deep.property('users[0].createdAt');
         expect(body.users[0].firstName).to.equal('Peter');

--- a/server/tests/unit/user-test.js
+++ b/server/tests/unit/user-test.js
@@ -2,6 +2,7 @@ var User = require('../../api/models/User');
 var Sails = require('sails').Sails;
 var sinon = require('sinon');
 var expect = require('chai').expect;
+var path = require('path');
 
 
 describe('Users', function() {
@@ -12,11 +13,36 @@ describe('Users', function() {
       log: {
         level: 'warn'
       },
+      models: {
+        connection: 'test',
+        migrate: 'drop'
+      },
+      eslint: {
+        check: false
+      },
       hooks: {
-        grunt: false
+        grunt: false,
+        views: false,
+        cors: false,
+        csrf: false,
+        i18n: false,
+        pubsub: false,
+        session: false
       }
-    }, function whenAppIsReady(err, sailsApp) {
-      done(err, sailsApp);
+    }, function whenAppIsReady(error, sailsApp) {
+      if (error) {
+        done(error, sailsApp);
+      }
+
+      // Require barrels and load fixtures
+      var Barrels = require('barrels');
+      var barrels = new Barrels(path.join(process.cwd(), 'tests', 'fixtures'));
+
+      // Populate the DB
+      barrels.populate(function (error) {
+        done(error, sailsApp);
+      });
+
     });
   });
 
@@ -94,7 +120,40 @@ describe('Users', function() {
   });
 
   describe('when the json form of the user is requested', function() {
-    it('sound return valid json representation');
+    it('should return valid json representation', function(done) {
+      sails.request({
+        url: '/api/v1/users',
+        method: 'GET',
+        params: {},
+        headers: {}
+      }, function(err, clientRes, body) {
+        expect(err).not.to.exist;
+        expect(clientRes.statusCode).to.equal(200);
+        console.log(body);
+        expect(body).to.include.keys('posts', 'vendors', 'photos', 'albums', 'statuses', 'events');
+        done();
+      });
+    });
+
+    it('should match the created users', function(done) {
+      sails.request({
+        url: '/api/v1/users',
+        method: 'GET',
+        params: {},
+        headers: {}
+      }, function(err, clientRes, body) {
+        expect(body).to.have.deep.property('people[0].id');
+        expect(body).to.have.deep.property('people[0].createdAt');
+        console.log(body)
+        expect(body.people[0].firstName).to.equal('Peter');
+        expect(body.people[0].lastName).to.equal('Test');
+        expect(body.people[0].email).to.equal('peter@test.com');
+        expect(body.people[0].password).to.not.equal('super-secure');
+        expect(body.people[1].firstName).to.equal('First');
+        expect(body.people[2].email).to.equal('john.original@email.com');
+        done();
+      });
+    });
     it('should not include the password');
   });
 


### PR DESCRIPTION
Since I have already done the work @mgenev I thought I would make a PR out of it so we can see what is useful in here and what not.

I changed the tests to use `sails-disk` so they would work in any environment. I guess one possible drawback here is it would not catch adapter specific errors (such as the many-to-many mongo error).

Deactivated all the hooks we don't need and added some barrel objects.

Both of the tests I added still fail because they need a JWT token to access the resource. I suppose adding a test such as `should error without JWT token` would be useful as well.