### PR TITLE
illustrate transitioning on auth

### DIFF
--- a/client/app/pods/index/route.js
+++ b/client/app/pods/index/route.js
@@ -1,4 +1,12 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+	beforeModel: function(transition, queryParams){
+		if (this.get('session.isAuthenticated')){
+			this.transitionTo('user', this.get('session.user.owner') );
+		} else {
+			this.transitionTo('login');
+		}
+		this._super(transition, queryParams);
+	},
 });


### PR DESCRIPTION
This is more of a brainstorming than a cooked PR. I think it would be cool to illustrate transitioning based on whether the user is authenticated or not. At the moment, this home route mixes login with whatever, but it would be cool to actually transition the user to login if not logged in, and otherwise transition him/her to say his/her dashboard at `/user/:id`.

If one would want to go in more details some configs could be added to config/environment.js:
```
      authenticationRoute:         'login',
      routeAfterAuthentication:    'application',
      routeIfAlreadyAuthenticated: 'application',
```