### PR TITLE
asyncToGenerator assumes a runtime that understands generators. Few b…

### DIFF
--- a/client/Brocfile.js
+++ b/client/Brocfile.js
@@ -5,7 +5,7 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 var app = new EmberApp({
   babel: {
     optional: [
-      'asyncToGenerator',
+      'es7.asyncFunctions',
       'es7.decorators'
    ]
   }


### PR DESCRIPTION
…rowsers (latest chrome, maybe ff) support this. But tools like uglify do not